### PR TITLE
refactor: use `repo.entries` to locate anime dirs

### DIFF
--- a/src/components/subtitles.tsx
+++ b/src/components/subtitles.tsx
@@ -1,7 +1,7 @@
 import {
-  getSubtitleDirs,
+  getAnimeDirs,
   importFansub,
-  type ISubtitlesDir,
+  type IAnimeDir,
   type ISubtitlesRepo,
 } from '~/lib/fansub'
 import { fetchRepoFiles, type IRepo } from '~/lib/github'
@@ -20,7 +20,7 @@ export async function Subtitles({ slug }: { slug: string }) {
 
 async function Repo({ repo }: { repo: ISubtitlesRepo }) {
   const { files } = await fetchRepoFiles(repo)
-  const subtitleDirs = getSubtitleDirs(files, repo.entries)
+  const animeDirs = getAnimeDirs(files, repo.entries)
   return (
     <li>
       <h3 className="mb-2 flex items-center text-sm text-muted-foreground">
@@ -44,34 +44,28 @@ async function Repo({ repo }: { repo: ISubtitlesRepo }) {
         </a>
       </h3>
       <ul>
-        {subtitleDirs.map((sd) => (
-          <SubtitlesDir key={sd.path} repo={repo} subtitleDir={sd} />
+        {animeDirs.map((ad) => (
+          <AnimeDir key={ad.path} repo={repo} animeDir={ad} />
         ))}
       </ul>
     </li>
   )
 }
 
-function SubtitlesDir({
-  repo,
-  subtitleDir: sd,
-}: {
-  repo: IRepo
-  subtitleDir: ISubtitlesDir
-}) {
+function AnimeDir({ repo, animeDir }: { repo: IRepo; animeDir: IAnimeDir }) {
   return (
     <li>
       <h3 className="text-lg">
-        {sd.parent && (
-          <span className="text-muted-foreground">{sd.parent}/</span>
+        {animeDir.parent && (
+          <span className="text-muted-foreground">{animeDir.parent}/</span>
         )}
         <a
-          href={`https://github.com/${repo.owner}/${repo.name}/tree/${repo.branch}/${sd.path}`}
+          href={`https://github.com/${repo.owner}/${repo.name}/tree/${repo.branch}/${animeDir.path}`}
           className="text-blue-600 hover:text-blue-800"
           target="_blank"
           rel="noopener noreferrer"
         >
-          {sd.name}
+          {animeDir.name}
         </a>
       </h3>
     </li>

--- a/src/components/subtitles.tsx
+++ b/src/components/subtitles.tsx
@@ -1,8 +1,8 @@
 import {
   getSubtitleDirs,
   importFansub,
-  type Fansub,
   type ISubtitlesDir,
+  type ISubtitlesRepo,
 } from '~/lib/fansub'
 import { fetchRepoFiles, type IRepo } from '~/lib/github'
 import { GoRepo } from 'react-icons/go'
@@ -12,15 +12,15 @@ export async function Subtitles({ slug }: { slug: string }) {
   return (
     <ul className="space-y-4">
       {fansub.repos.map((repo) => (
-        <Repo key={repo.name} repo={repo} fansub={fansub} />
+        <Repo key={repo.name} repo={repo} />
       ))}
     </ul>
   )
 }
 
-async function Repo({ repo, fansub }: { repo: IRepo; fansub: Fansub }) {
+async function Repo({ repo }: { repo: ISubtitlesRepo }) {
   const { files } = await fetchRepoFiles(repo)
-  const subtitleDirs = getSubtitleDirs(files, fansub.subtitle?.patterns)
+  const subtitleDirs = getSubtitleDirs(files, repo.entries)
   return (
     <li>
       <h3 className="mb-2 flex items-center text-sm text-muted-foreground">

--- a/src/fansubs/billionmetalab.ts
+++ b/src/fansubs/billionmetalab.ts
@@ -9,6 +9,7 @@ export default {
       owner: 'microseventh',
       name: 'BillionMetaLab_AssSubs',
       branch: 'main',
+      entries: [/(^\d{6})/],
     },
   ],
   links: {

--- a/src/fansubs/haruhana.ts
+++ b/src/fansubs/haruhana.ts
@@ -21,7 +21,4 @@ export default {
     qq: 'https://qm.qq.com/q/LFOmKxHXsm',
     email: 'mailto:mharuhanasub@gmail.com',
   },
-  subtitle: {
-    patterns: [/\/([^/]+\[Subtitles\]\.7z)$/],
-  },
 } satisfies Fansub

--- a/src/fansubs/kitauji.ts
+++ b/src/fansubs/kitauji.ts
@@ -10,6 +10,7 @@ export default {
       owner: 'Kitauji-Sub',
       name: 'Subtitles',
       branch: 'main',
+      entries: ['Movie', 'OVA', /(^TV\/\d{4}\/\d{2})/],
     },
   ],
   links: {

--- a/src/fansubs/lksub.ts
+++ b/src/fansubs/lksub.ts
@@ -1,4 +1,4 @@
-import { defaultSubtitlePattern, type Fansub } from '~/lib/fansub'
+import { type Fansub } from '~/lib/fansub'
 
 export default {
   slug: 'lksub',
@@ -12,7 +12,4 @@ export default {
     },
   ],
   links: {},
-  subtitle: {
-    patterns: [/\/(\d+\/[^/]+\.ass)$/, defaultSubtitlePattern],
-  },
 } satisfies Fansub

--- a/src/fansubs/mingy.ts
+++ b/src/fansubs/mingy.ts
@@ -8,6 +8,7 @@ export default {
       owner: 'MingYSub',
       name: 'SubsArchive',
       branch: 'main',
+      entries: ['Archive'],
     },
   ],
   links: {

--- a/src/fansubs/mmsub.ts
+++ b/src/fansubs/mmsub.ts
@@ -9,6 +9,7 @@ export default {
       owner: 'DMYJS',
       name: 'MMSUB',
       branch: 'master',
+      entries: ['Animation/Movie', /(^Animation\/\d{4})/],
     },
   ],
   links: {

--- a/src/fansubs/sweetsub.ts
+++ b/src/fansubs/sweetsub.ts
@@ -8,6 +8,7 @@ export default {
       owner: 'SweetSub',
       name: 'SweetSub',
       branch: 'master',
+      entries: [],
     },
   ],
   links: {

--- a/src/fansubs/sweetsub.ts
+++ b/src/fansubs/sweetsub.ts
@@ -8,7 +8,7 @@ export default {
       owner: 'SweetSub',
       name: 'SweetSub',
       branch: 'master',
-      entries: [],
+      entries: ['Archive'],
     },
   ],
   links: {

--- a/src/lib/fansub.ts
+++ b/src/lib/fansub.ts
@@ -2,7 +2,7 @@ import { readdir } from 'node:fs/promises'
 import { join } from 'node:path'
 import { type IRepo, type IRepoFile } from './github'
 
-export interface ISubtitlesDir {
+export interface IAnimeDir {
   name: string
   path: string
   parent?: string
@@ -10,8 +10,8 @@ export interface ISubtitlesDir {
 
 export interface ISubtitlesRepo extends IRepo {
   /**
-   * Array of patterns to specify where subtitle directories are located.
-   * Directories under an entry will be considered as subtitle directories.
+   * Array of patterns to specify where anime directories are located.
+   * Directories under an entry will be considered as anime directories.
    *
    * If not provided or empty, the root directory will be used.
    *
@@ -56,11 +56,11 @@ export interface Fansub {
   }
 }
 
-export function getSubtitleDirs(
+export function getAnimeDirs(
   files: IRepoFile[],
   entries: ISubtitlesRepo['entries'] = [''],
-): ISubtitlesDir[] {
-  const subtitleDirs: Map<string, ISubtitlesDir> = new Map()
+): IAnimeDir[] {
+  const animeDirs: Map<string, IAnimeDir> = new Map()
 
   for (const item of files) {
     const entry = entries.find((entry) =>
@@ -82,8 +82,8 @@ export function getSubtitleDirs(
     const dirName = parts[0]
     const dirPath = join(entryPath, dirName)
 
-    if (!subtitleDirs.has(dirPath)) {
-      subtitleDirs.set(dirPath, {
+    if (!animeDirs.has(dirPath)) {
+      animeDirs.set(dirPath, {
         path: dirPath,
         name: dirName,
         parent: entryPath,
@@ -91,7 +91,7 @@ export function getSubtitleDirs(
     }
   }
 
-  return Array.from(subtitleDirs.values()).sort((a, b) =>
+  return Array.from(animeDirs.values()).sort((a, b) =>
     a.path.localeCompare(b.path),
   )
 }

--- a/src/lib/fansub.ts
+++ b/src/lib/fansub.ts
@@ -1,5 +1,5 @@
-import assert from 'node:assert'
 import { readdir } from 'node:fs/promises'
+import { join } from 'node:path'
 import { type IRepo, type IRepoFile } from './github'
 
 export interface ISubtitlesDir {
@@ -73,7 +73,7 @@ export function getSubtitleDirs(
     if (parts.length === 1) continue
 
     const dirName = parts[0]
-    const dirPath = entryPath + dirName
+    const dirPath = join(entryPath, dirName)
 
     if (!subtitleDirs.has(dirPath)) {
       subtitleDirs.set(dirPath, {

--- a/src/lib/fansub.ts
+++ b/src/lib/fansub.ts
@@ -62,28 +62,25 @@ export function getAnimeDirs(
 ): IAnimeDir[] {
   const animeDirs: IAnimeDir[] = []
 
-  for (const item of files) {
+  for (const f of files) {
     const last = animeDirs[animeDirs.length - 1]
 
     // Skip if the anime dir is already in the list
-    if (last && item.path.startsWith(last.path)) continue
+    if (last && f.path.startsWith(last.path)) continue
 
-    const entry = entries.find((entry) =>
-      typeof entry === 'string'
-        ? item.path.startsWith(entry)
-        : entry.test(item.path),
+    const entry = entries.find((e) =>
+      typeof e === 'string' ? f.path.startsWith(e) : e.test(f.path),
     )
 
     // Skip if the file is not in any entry
     if (entry === undefined) continue
 
     const entryPath =
-      typeof entry === 'string' ? entry : item.path.match(entry)![1]
-
-    const restPath = item.path.slice(entryPath.length).replace(/^\//, '')
+      typeof entry === 'string' ? entry : f.path.match(entry)![1]
+    const restPath = f.path.slice(entryPath.length).replace(/^\//, '')
     const parts = restPath.split('/')
 
-    // Skip if the path is not a directory
+    // Skip if the file is not a directory
     if (parts.length === 1) continue
 
     const dirName = parts[0]

--- a/src/lib/fansub.ts
+++ b/src/lib/fansub.ts
@@ -9,7 +9,14 @@ export interface ISubtitlesDir {
 }
 
 export interface ISubtitlesRepo extends IRepo {
-  /** Array of regular expressions to match the entries in the repository */
+  /**
+   * Array of patterns to specify where subtitle directories are located.
+   * Directories under an entry will be considered as subtitle directories.
+   *
+   * If not provided or empty, the root directory will be used.
+   *
+   * @default ['']
+   */
   entries?: Array<string | RegExp>
 }
 

--- a/src/lib/fansub.ts
+++ b/src/lib/fansub.ts
@@ -6,7 +6,6 @@ export interface ISubtitlesDir {
   name: string
   path: string
   parent?: string
-  subtitles: string[]
 }
 
 export interface Fansub {
@@ -64,7 +63,6 @@ export function getSubtitleDirs(
     if (!entryMatch) continue
 
     const pathParts = item.path.split('/')
-    const fileName = pathParts.pop() || ''
     const animeName = pathParts.pop() || ''
     const dirPath = pathParts.join('/')
 
@@ -75,12 +73,8 @@ export function getSubtitleDirs(
           path: dirPath + '/' + animeName,
           name: animeName,
           parent: dirPath,
-          subtitles: [],
         }
         subtitleDirs.set(dirPath + '/' + animeName, sd)
-      }
-      if (!sd.subtitles.includes(fileName)) {
-        sd.subtitles.push(fileName)
       }
     }
   }

--- a/src/lib/fansub.ts
+++ b/src/lib/fansub.ts
@@ -10,7 +10,7 @@ export interface ISubtitlesDir {
 
 export interface ISubtitlesRepo extends IRepo {
   /** Array of regular expressions to match the entries in the repository */
-  entries: RegExp[]
+  entries: string[]
 }
 
 export interface Fansub {
@@ -51,29 +51,25 @@ export interface Fansub {
 
 export function getSubtitleDirs(
   files: IRepoFile[],
-  entries: RegExp[],
+  entries: string[] = [''],
 ): ISubtitlesDir[] {
   const subtitleDirs: Map<string, ISubtitlesDir> = new Map()
 
   for (const item of files) {
     // Check if the file is in a subtitle entry directory
-    const entryMatch = entries.some((re) => re.test(item.path))
-    if (!entryMatch) continue
+    const entry = entries.find((entry) => item.path.startsWith(entry))
+    if (!entry) continue
 
-    const pathParts = item.path.split('/')
-    const animeName = pathParts.pop() || ''
-    const dirPath = pathParts.join('/')
+    const restPath = item.path.slice(entry.length + 1)
+    const dirName = restPath.split('/')[0]
+    const dirPath = entry + dirName
 
-    if (animeName) {
-      let sd = subtitleDirs.get(dirPath + '/' + animeName)
-      if (!sd) {
-        sd = {
-          path: dirPath + '/' + animeName,
-          name: animeName,
-          parent: dirPath,
-        }
-        subtitleDirs.set(dirPath + '/' + animeName, sd)
-      }
+    if (!subtitleDirs.has(dirPath)) {
+      subtitleDirs.set(dirPath, {
+        path: dirPath,
+        name: dirName,
+        parent: entry,
+      })
     }
   }
 

--- a/src/lib/fansub.ts
+++ b/src/lib/fansub.ts
@@ -67,7 +67,12 @@ export function getSubtitleDirs(
       typeof entry === 'string' ? entry : item.path.match(entry)![1]
 
     const restPath = item.path.slice(entryPath.length + 1)
-    const dirName = restPath.split('/')[0]
+    const parts = restPath.split('/')
+
+    // Skip if the path is not a directory
+    if (parts.length === 1) continue
+
+    const dirName = parts[0]
     const dirPath = entryPath + dirName
 
     if (!subtitleDirs.has(dirPath)) {

--- a/src/lib/fansub.ts
+++ b/src/lib/fansub.ts
@@ -10,7 +10,7 @@ export interface ISubtitlesDir {
 
 export interface ISubtitlesRepo extends IRepo {
   /** Array of regular expressions to match the entries in the repository */
-  entries: Array<string | RegExp>
+  entries?: Array<string | RegExp>
 }
 
 export interface Fansub {
@@ -61,12 +61,12 @@ export function getSubtitleDirs(
         ? item.path.startsWith(entry)
         : entry.test(item.path),
     )
-    if (!entry) continue
+    if (entry === undefined) continue
 
     const entryPath =
       typeof entry === 'string' ? entry : item.path.match(entry)![1]
 
-    const restPath = item.path.slice(entryPath.length + 1)
+    const restPath = item.path.slice(entryPath.length).replace(/^\//, '')
     const parts = restPath.split('/')
 
     // Skip if the path is not a directory

--- a/src/lib/fansub.ts
+++ b/src/lib/fansub.ts
@@ -8,6 +8,11 @@ export interface ISubtitlesDir {
   parent?: string
 }
 
+export interface ISubtitlesRepo extends IRepo {
+  /** Array of regular expressions to match the entries in the repository */
+  entries: RegExp[]
+}
+
 export interface Fansub {
   /** Unique identifier for the fansub */
   slug: string
@@ -20,7 +25,7 @@ export interface Fansub {
   /** URL of the fansub's avatar */
   avatar?: string
   /** Array of GitHub repositories associated with the fansub */
-  repos: IRepo[]
+  repos: ISubtitlesRepo[]
   /** Various social media and contact links for the fansub */
   links: {
     /** Official website URL */
@@ -41,13 +46,6 @@ export interface Fansub {
     email?: string
     /** Sponsorship or donation URL */
     sponsor?: string
-  }
-  /** Configuration for subtitle directory handling */
-  subtitle?: {
-    /**
-     * Array of regular expressions to identify subtitle entry directories
-     */
-    entries: RegExp[]
   }
 }
 


### PR DESCRIPTION
This reduces the complexity of locating anime directories, compared with the previous `subtitle.patterns`